### PR TITLE
Fix navigation hierearchy.

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -24,8 +24,11 @@
 
 namespace block_multiblock;
 
+use block_multiblock\navigation;
 use context;
 use context_block;
+use moodle_url;
+use navigation_node;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -58,8 +61,30 @@ class helper {
         }
 
         $PAGE->set_context($blockctx);
-        $PAGE->set_url($blockctx->get_url());
+        $actualpageurl = navigation::get_page_url($blockid);
+        $PAGE->set_url($actualpageurl);
         $PAGE->set_pagelayout('admin');
+
+        // The my-dashboard page adds an additional 'phantom' block region to cope with the dashboard content.
+        if (navigation::is_dashboard($actualpageurl)) {
+            $PAGE->blocks->add_region('content');
+            // For some reason, adding extra navbar items to dashboard requires doing it twice.
+            $PAGE->navbar->add(get_string('managemultiblock', 'block_multiblock', $blockinstance->get_title()),
+                new moodle_url('/blocks/multiblock/manage.php', ['id' => $blockid, 'sesskey' => sesskey()]));
+        }
+
+        if (navigation::is_admin_url($actualpageurl)) {
+            navigation_node::require_admin_tree();
+        }
+
+        $PAGE->navigation->initialise();
+        $PAGE->navbar->add(get_string('managemultiblock', 'block_multiblock', $blockinstance->get_title()),
+            new moodle_url('/blocks/multiblock/manage.php', ['id' => $blockid, 'sesskey' => sesskey()]));
+
+        require_sesskey();
+
+        $PAGE->set_title(get_string('managemultiblocktitle', 'block_multiblock', $blockinstance->title));
+        $PAGE->set_heading(get_string('managemultiblocktitle', 'block_multiblock', $blockinstance->title));
 
         return [$block, $blockinstance];
     }

--- a/classes/navigation.php
+++ b/classes/navigation.php
@@ -68,6 +68,9 @@ class navigation {
 
         // If this is a system context, something really interesting could be happening.
         if ($parentcontext instanceof context_system) {
+            if ($block->pagetypepattern == 'my-index') {
+                return new moodle_url('/my/indexsys.php');
+            }
             return static::map_site_context_url($block->pagetypepattern, $parentcontext);
         }
 
@@ -145,5 +148,29 @@ class navigation {
 
         // Just in case, we can always try the context's URL - that will get us *something*.
         return $context->get_url();
+    }
+
+    /**
+     * Identifies if the specified URL is a dashboard.
+     *
+     * @param moodle_url $url The URL of the page in question.
+     * @return bool True if the page is a dashboard.
+     */
+    public static function is_dashboard(moodle_url $url): bool {
+        $local = $url->out_as_local_url(false);
+        return strpos($local, '/my/') === 0 && strpos($local, '/my/indexsys') === false;
+    }
+
+    /**
+     * Identifies if the specified URL is somewhere inside the admin panel.
+     *
+     * @param moodle_url $url The URL of the page in question.
+     * @return bool True if the page is an admin page.
+     */
+    public static function is_admin_url(moodle_url $url): bool {
+        global $CFG;
+
+        $local = $url->out_as_local_url(false);
+        return strpos($local, '/' . $CFG->admin . '/') === 0 || strpos($local, '/my/indexsys') === 0;
     }
 }

--- a/configinstance.php
+++ b/configinstance.php
@@ -32,18 +32,6 @@ $blockid = required_param('id', PARAM_INT);
 $actionableinstance = required_param('instance', PARAM_INT);
 
 list($block, $blockinstance) = helper::bootstrap_page($blockid);
-
-// The my-dashboard page adds an additional 'phantom' block region to cope with the dashboard content.
-if ($block->pagetypepattern == 'my-index') {
-    $PAGE->blocks->add_region('content');
-} else {
-    // But if we're on anything other than my dashboard, we want to initialise the navbar fully.
-    $PAGE->navigation->initialise();
-}
-
-$PAGE->navbar->add(get_string('managemultiblock', 'block_multiblock', $blockinstance->get_title()),
-    new moodle_url('/blocks/multiblock/manage.php', ['id' => $blockid, 'sesskey' => sesskey()]));
-
 require_login();
 
 $blockmanager = $PAGE->blocks;
@@ -53,8 +41,7 @@ if (!$blockinstance->user_can_edit() && !$this->page->user_can_edit_blocks()) {
 }
 
 $pageurl = new moodle_url('/blocks/multiblock/configinstance.php', ['id' => $blockid, 'instance' => $actionableinstance]);
-$PAGE->set_title(get_string('managemultiblock', 'block_multiblock', $blockinstance->title));
-$PAGE->set_heading(get_string('managemultiblock', 'block_multiblock', $blockinstance->title));
+$PAGE->set_url($pageurl);
 
 $blockmanager->show_only_fake_blocks(true);
 

--- a/lang/en/block_multiblock.php
+++ b/lang/en/block_multiblock.php
@@ -27,6 +27,7 @@ $string['pluginname'] = 'Multiblock';
 $string['addnewblock'] = 'Add a new sub-block';
 $string['blocktitle'] = 'Block title';
 $string['managemultiblock'] = 'Manage {$a} contents';
+$string['managemultiblocktitle'] = 'Manage multiblock: {$a}';
 $string['moveexistingblock'] = 'Move existing block';
 $string['movetoparentpage'] = 'Move to parent page';
 $string['multiblockhasnosubblocks'] = 'This multiblock has no blocks inside it.';

--- a/manage.php
+++ b/manage.php
@@ -34,17 +34,6 @@ $actionableinstance = optional_param('instance', 0, PARAM_INT);
 $performaction = optional_param('action', '', PARAM_TEXT);
 
 list($block, $blockinstance) = helper::bootstrap_page($blockid);
-
-// The my-dashboard page adds an additional 'phantom' block region to cope with the dashboard content.
-if ($block->pagetypepattern == 'my-index') {
-    $PAGE->blocks->add_region('content');
-} else {
-    // But if we're on anything other than my dashboard, we want to initialise the navbar fully.
-    $PAGE->navigation->initialise();
-}
-
-$PAGE->navbar->add(get_string('managemultiblock', 'block_multiblock', $blockinstance->get_title()));
-
 require_login();
 
 $blockmanager = $PAGE->blocks;
@@ -56,8 +45,6 @@ if (!$blockinstance->user_can_edit() && !$this->page->user_can_edit_blocks()) {
 // Now we've done permissions checks, reset the URL to be the real one.
 $pageurl = new moodle_url('/blocks/multiblock/manage.php', ['id' => $blockid]);
 $PAGE->set_url($pageurl);
-$PAGE->set_title(get_string('managemultiblock', 'block_multiblock', $blockinstance->title));
-$PAGE->set_heading(get_string('managemultiblock', 'block_multiblock', $blockinstance->title));
 
 $blockmanager->show_only_fake_blocks(true);
 
@@ -79,7 +66,7 @@ if ($newblockdata = $addblock->get_data()) {
 
         // Now we need to re-prep the table exist.
         $forcereload = true;
-    } else if (!empty($newblockdata->movesubmit) && $newblockdata->moveblock) {
+    } else if (!empty($newblockdata->movesubmit) && !empty($newblockdata->moveblock)) {
         // Merge it in and then reprep the table and form.
         helper::move_block($newblockdata->moveblock, $blockid);
         $forcereload = true;


### PR DESCRIPTION
* Drag more of the common set up into the setup routine.
* Separate the title from the last entry to better cope with Moodle being helpful.
* When on an 'admin URL' initialise the admin hierarchy for breadcrumbs.

Should fix #12. Appears to fix #13.