### PR TITLE
Restructure all the layouts into their own classes.

### DIFF
--- a/block_multiblock.php
+++ b/block_multiblock.php
@@ -252,40 +252,20 @@ class block_multiblock extends block_base {
         static $presentations = null;
 
         if ($presentations === null) {
-            $presentations = [
-                'accordion' => [
-                    'name' => get_string('presentation:accordion', 'block_multiblock'),
-                    'template' => 'block_multiblock/accordion',
-                    'requires_title' => true,
-                ],
-                'columns-2-33-66' => [
-                    'name' => get_string('presentation:columns-2-33-66', 'block_multiblock'),
-                    'template' => 'block_multiblock/columns-2-33-66',
-                ],
-                'columns-2equal' => [
-                    'name' => get_string('presentation:columns-2equal', 'block_multiblock'),
-                    'template' => 'block_multiblock/columns-2equal',
-                ],
-                'columns-2-66-33' => [
-                    'name' => get_string('presentation:columns-2-66-33', 'block_multiblock'),
-                    'template' => 'block_multiblock/columns-2-66-33',
-                ],
-                'dropdown' => [
-                    'name' => get_string('presentation:dropdown', 'block_multiblock'),
-                    'template' => 'block_multiblock/dropdown',
-                    'requires_title' => true,
-                ],
-                'tabbed-list' => [
-                    'name' => get_string('presentation:tabbed', 'block_multiblock'),
-                    'template' => 'block_multiblock/tabbed-list',
-                    'requires_title' => true,
-                ],
-                'vertical-tabbed-list' => [
-                    'name' => get_string('presentation:vertical-tabs', 'block_multiblock'),
-                    'template' => 'block_multiblock/vertical-tabbed-list',
-                    'requires_title' => true,
-                ],
-            ];
+
+            foreach (core_component::get_component_classes_in_namespace('block_multiblock', 'layout') as $class => $ns) {
+                if (strpos($class, $ns[0]) === 0) {
+                    // We only care about non-abstract classes here.
+                    $reflection = new ReflectionClass($class);
+                    if ($reflection->isAbstract()) {
+                        continue;
+                    }
+                    $classname = substr($class, strlen($ns[0]));
+
+                    $instance = new $class;
+                    $presentations[$instance->get_layout_id()] = $instance;
+                }
+            }
         }
 
         return $presentations;

--- a/changelog.php
+++ b/changelog.php
@@ -15,17 +15,29 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Plugin version and other meta-data are defined here.
+ * Changelog.
  *
  * @package   block_multiblock
- * @copyright 2019 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020021101;
-$plugin->release   = '1.0.2';
-$plugin->requires  = 2018051700; // Moodle 3.5.0.
-$plugin->component = 'block_multiblock';
-$plugin->maturity  = MATURITY_ALPHA;
+?>
+
+Multiblock Changelog.
+(File protected as a .php file to avoid leaking details of instance in use.)
+
+1.0.2 - 2020021101
+ * Added a changelog.
+ * Added badges to the readme.
+ * Refactored some internals to allow future development. (#29)
+
+
+1.0.1 - 2020021100
+ * Added save-and-display option to the editing a subblock instance. (#25)
+
+
+1.0.0 - 2019092600
+ * Initial code, not initially released under this version except on GitHub.

--- a/classes/form/editblock.php
+++ b/classes/form/editblock.php
@@ -91,7 +91,7 @@ class editblock extends block_multiblock_proxy_edit_form {
             $presentations = block_multiblock::get_valid_presentations();
             $defaultconfig = (object) ['presentation' => block_multiblock::get_default_presentation()];
             $config = !empty($this->multiblock->config) ? $this->multiblock->config : $defaultconfig;
-            if (!empty($presentations[$config->presentation]['requires_title'])) {
+            if ($presentations[$config->presentation]->requires_title()) {
                 $requiredmsg = get_string('requirestitle', 'block_multiblock', $this->multiblock->get_title());
                 $mform->addRule('config_title', $requiredmsg, 'required', null, 'client');
             }

--- a/classes/layout/abstract_layout.php
+++ b/classes/layout/abstract_layout.php
@@ -1,0 +1,75 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Behaviour for a base abstract layout.
+ *
+ * @package   block_multiblock
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_multiblock\layout;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Behaviour for a base abstract layout.
+ *
+ * @package   block_multiblock
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+abstract class abstract_layout {
+
+    /**
+     * Returns the internal ID that this layout would use and be identified by.
+     *
+     * Defaults to the class name.
+     *
+     * @return string The layout ID.
+     */
+    public function get_layout_id() : string {
+        return substr(strrchr(get_class($this), '\\'), 1);
+    }
+
+    /**
+     * Returns the block layout's name.
+     *
+     * @return string The layout's name.
+     */
+    public function get_name() : string {
+        return get_string('presentation:' . $this->get_layout_id(), 'block_multiblock');
+    }
+
+    /**
+     * Returns whether this block layout requires a title for sub-blocks.
+     *
+     * @return bool True if the sub-block title is required.
+     */
+    public function requires_title() : bool {
+        return true;
+    }
+
+    /**
+     * Returns the Mustache template required to render this block.
+     *
+     * @return string The Mustache template.
+     */
+    public function get_template() : string {
+        return 'block_multiblock/' . $this->get_layout_id();
+    }
+}

--- a/classes/layout/accordion.php
+++ b/classes/layout/accordion.php
@@ -15,17 +15,24 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Plugin version and other meta-data are defined here.
+ * Behaviour for accordion layout.
  *
  * @package   block_multiblock
- * @copyright 2019 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_multiblock\layout;
+
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020021101;
-$plugin->release   = '1.0.2';
-$plugin->requires  = 2018051700; // Moodle 3.5.0.
-$plugin->component = 'block_multiblock';
-$plugin->maturity  = MATURITY_ALPHA;
+/**
+ * Behaviour for accordion layout.
+ *
+ * @package   block_multiblock
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class accordion extends abstract_layout {
+
+}

--- a/classes/layout/columns_2_33_66.php
+++ b/classes/layout/columns_2_33_66.php
@@ -1,0 +1,57 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Behaviour for columns-2-33-66 layout.
+ *
+ * @package   block_multiblock
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_multiblock\layout;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Behaviour for columns-2-33-66 layout.
+ *
+ * @package   block_multiblock
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class columns_2_33_66 extends abstract_layout {
+
+    /**
+     * Returns the internal ID that this layout would use and be identified by.
+     *
+     * Defaults to the class name.
+     *
+     * @return string The layout ID.
+     */
+    public function get_layout_id() : string {
+        return 'columns-2-33-66';
+    }
+
+    /**
+     * Returns whether this block layout requires a title for sub-blocks.
+     *
+     * @return bool True if the sub-block title is required.
+     */
+    public function requires_title() : bool {
+        return false;
+    }
+}

--- a/classes/layout/columns_2_66_33.php
+++ b/classes/layout/columns_2_66_33.php
@@ -1,0 +1,57 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Behaviour for columns-2-66-33 layout.
+ *
+ * @package   block_multiblock
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_multiblock\layout;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Behaviour for columns-2-66-33 layout.
+ *
+ * @package   block_multiblock
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class columns_2_66_33 extends abstract_layout {
+
+    /**
+     * Returns the internal ID that this layout would use and be identified by.
+     *
+     * Defaults to the class name.
+     *
+     * @return string The layout ID.
+     */
+    public function get_layout_id() : string {
+        return 'columns-2-66-33';
+    }
+
+    /**
+     * Returns whether this block layout requires a title for sub-blocks.
+     *
+     * @return bool True if the sub-block title is required.
+     */
+    public function requires_title() : bool {
+        return false;
+    }
+}

--- a/classes/layout/columns_2equal.php
+++ b/classes/layout/columns_2equal.php
@@ -1,0 +1,57 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Behaviour for columns-2equal layout.
+ *
+ * @package   block_multiblock
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_multiblock\layout;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Behaviour for columns-2equal layout.
+ *
+ * @package   block_multiblock
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class columns_2equal extends abstract_layout {
+
+    /**
+     * Returns the internal ID that this layout would use and be identified by.
+     *
+     * Defaults to the class name.
+     *
+     * @return string The layout ID.
+     */
+    public function get_layout_id() : string {
+        return 'columns-2equal';
+    }
+
+    /**
+     * Returns whether this block layout requires a title for sub-blocks.
+     *
+     * @return bool True if the sub-block title is required.
+     */
+    public function requires_title() : bool {
+        return false;
+    }
+}

--- a/classes/layout/dropdown.php
+++ b/classes/layout/dropdown.php
@@ -15,17 +15,24 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Plugin version and other meta-data are defined here.
+ * Behaviour for dropdown layout.
  *
  * @package   block_multiblock
- * @copyright 2019 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_multiblock\layout;
+
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020021101;
-$plugin->release   = '1.0.2';
-$plugin->requires  = 2018051700; // Moodle 3.5.0.
-$plugin->component = 'block_multiblock';
-$plugin->maturity  = MATURITY_ALPHA;
+/**
+ * Behaviour for dropdown layout.
+ *
+ * @package   block_multiblock
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class dropdown extends abstract_layout {
+
+}

--- a/classes/layout/tabbed_list.php
+++ b/classes/layout/tabbed_list.php
@@ -15,17 +15,34 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Plugin version and other meta-data are defined here.
+ * Behaviour for tabbed-list layout.
  *
  * @package   block_multiblock
- * @copyright 2019 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_multiblock\layout;
+
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020021101;
-$plugin->release   = '1.0.2';
-$plugin->requires  = 2018051700; // Moodle 3.5.0.
-$plugin->component = 'block_multiblock';
-$plugin->maturity  = MATURITY_ALPHA;
+/**
+ * Behaviour for tabbed-list layout.
+ *
+ * @package   block_multiblock
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tabbed_list extends abstract_layout {
+
+    /**
+     * Returns the internal ID that this layout would use and be identified by.
+     *
+     * Defaults to the class name.
+     *
+     * @return string The layout ID.
+     */
+    public function get_layout_id() : string {
+        return 'tabbed-list';
+    }
+}

--- a/classes/layout/vertical_tabbed_list.php
+++ b/classes/layout/vertical_tabbed_list.php
@@ -15,17 +15,34 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Plugin version and other meta-data are defined here.
+ * Behaviour for vertical-tabbed-list layout.
  *
  * @package   block_multiblock
- * @copyright 2019 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_multiblock\layout;
+
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020021101;
-$plugin->release   = '1.0.2';
-$plugin->requires  = 2018051700; // Moodle 3.5.0.
-$plugin->component = 'block_multiblock';
-$plugin->maturity  = MATURITY_ALPHA;
+/**
+ * Behaviour for vertical-tabbed-list layout.
+ *
+ * @package   block_multiblock
+ * @copyright 2020 Peter Spicer <peter.spicer@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class vertical_tabbed_list extends abstract_layout {
+
+    /**
+     * Returns the internal ID that this layout would use and be identified by.
+     *
+     * Defaults to the class name.
+     *
+     * @return string The layout ID.
+     */
+    public function get_layout_id() : string {
+        return 'vertical-tabbed-list';
+    }
+}

--- a/classes/output/main.php
+++ b/classes/output/main.php
@@ -67,7 +67,7 @@ class main implements renderable, templatable {
     public function get_template(): string {
         $presentations = block_multiblock::get_valid_presentations();
         $presentation = isset($presentations[$this->template]) ? $this->template : block_multiblock::get_default_presentation();
-        return $presentations[$presentation]['template'];
+        return $presentations[$presentation]->get_template();
     }
 
     /**

--- a/edit_form.php
+++ b/edit_form.php
@@ -52,7 +52,7 @@ class block_multiblock_edit_form extends block_edit_form {
         $presentations = block_multiblock::get_valid_presentations();
         $options = [];
         foreach ($presentations as $presentationid => $presentation) {
-            $options[$presentationid] = $presentation['name'];
+            $options[$presentationid] = $presentation->get_name();
         }
         $mform->addElement('select', 'config_presentation', get_string('presentation', 'block_multiblock'), $options);
         $mform->setDefault('config_presentation', block_multiblock::get_default_presentation());

--- a/lang/en/block_multiblock.php
+++ b/lang/en/block_multiblock.php
@@ -46,8 +46,8 @@ $string['presentation:columns-2-33-66'] = 'Columns: 2 (33% / 66%)';
 $string['presentation:columns-2equal'] = 'Columns: 2 equal';
 $string['presentation:columns-2-66-33'] = 'Columns: 2 (66% / 33%)';
 $string['presentation:dropdown'] = 'Dropdown';
-$string['presentation:tabbed'] = 'Tabs';
-$string['presentation:vertical-tabs'] = 'Vertical Tabs';
+$string['presentation:tabbed-list'] = 'Tabs';
+$string['presentation:vertical-tabbed-list'] = 'Vertical Tabs';
 
 $string['table:actions'] = 'Actions';
 $string['table:blocktitle'] = 'Block title';


### PR DESCRIPTION
This serves as a prelude to #29 where rendering will be handed over to the layout classes rather than a single stock renderer (as itself a prelude to having everything in real subplugins one day?)

Anyway, this moves everything into its own classes, splitting out Totara specific versions is now somewhat simpler and fixing the pipeline to not have a single renderer is also trivial.