### PR TITLE
Disallow trying to move invalid blocks from the merge block UI.

### DIFF
--- a/changelog.php
+++ b/changelog.php
@@ -29,6 +29,9 @@ defined('MOODLE_INTERNAL') || die();
 Multiblock Changelog.
 (File protected as a .php file to avoid leaking details of instance in use.)
 
+1.3.2 - 2020060102
+ * Don't try to use invalid blocks as part of 'merge in block' (#62)
+
 1.3.1 - 2020060101
  * Stop running tests on 3.6.
  * Add 3.9 stable to the supported list.

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020060101;
-$plugin->release   = '1.3.1';
+$plugin->version   = 2020060102;
+$plugin->release   = '1.3.2';
 $plugin->requires  = !file_exists(__DIR__ . '/../../totara/core/lib.php') ? 2018051700 : 2017051509; // Moodle 3.5 / Totara 12.
 $plugin->component = 'block_multiblock';
 $plugin->maturity  = MATURITY_BETA;


### PR DESCRIPTION
Fixes the underlying cause of #62.