### PR TITLE
Issue #74 and #75 navigation improvements

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -138,6 +138,7 @@ class helper {
 
         // And hand over to the Moodle architecture to do its thing.
         $PAGE->navigation->initialise();
+        $PAGE->navbar->add(get_string('manageblocklocation', 'block_multiblock'), $actualpageurl);
         $PAGE->navbar->add(get_string('managemultiblock', 'block_multiblock', $blockinstance->get_title()),
             new moodle_url('/blocks/multiblock/manage.php', ['id' => $blockid, 'sesskey' => sesskey()]));
 

--- a/classes/navigation.php
+++ b/classes/navigation.php
@@ -80,6 +80,14 @@ class navigation {
             if ($block->pagetypepattern == 'my-index') {
                 return new moodle_url('/my/indexsys.php');
             }
+            if (strpos($block->pagetypepattern, 'totara-dashboard') === 0) {
+
+                if (preg_match('~^totara-dashboard-(\d+)$~', $block->pagetypepattern, $match)) {
+                    return new moodle_url('/totara/dashboard/layout.php', ['id' => $match[1]]);
+                }
+
+                return new moodle_url('/totara/dashboard/layout.php', ['id' => 1]);
+            }
             return static::map_site_context_url($block->pagetypepattern, $parentcontext);
         }
 

--- a/lang/en/block_multiblock.php
+++ b/lang/en/block_multiblock.php
@@ -27,6 +27,7 @@ $string['pluginname'] = 'Multiblock';
 $string['addnewblock'] = 'Add a new sub-block';
 $string['blocktitle'] = 'Block title';
 $string['editblock'] = 'Edit block';
+$string['manageblocklocation'] = 'Block location';
 $string['managemultiblock'] = 'Manage {$a} contents';
 $string['managemultiblocktitle'] = 'Manage multiblock: {$a}';
 $string['moveexistingblock'] = 'Move existing block';


### PR DESCRIPTION
* Add a breadcrumb to take user back to page containing block. Note that the string has to be generic, as no page title is provided.
* Add navigation check for totara dashboards that have the system context as parent context.