### PR TITLE
Return correct URL when block is on Workplace custom page

### DIFF
--- a/classes/navigation.php
+++ b/classes/navigation.php
@@ -78,6 +78,10 @@ class navigation {
             if ($block->pagetypepattern == 'my-index') {
                 return new moodle_url('/my/indexsys.php');
             }
+            // Fix for Workplace custom pages
+            if ($block->pagetypepattern == 'admin-tool-custompage') {
+                return new moodle_url('/admin/tool/custompage/view.php', ['id' => $block->subpagepattern]);
+            }
             if (strpos($block->pagetypepattern, 'totara-dashboard') !== false) {
 
                 if (preg_match('~^totara-dashboard-(\d+)$~', $block->pagetypepattern, $match)) {


### PR DESCRIPTION
Currently, this plugin doesn't work correctly when included in a custom page, [a feature of Moodle Workplace](https://docs.moodle.org/400/en/Custom_pages). When using the get_page_url method to determine the URL that the block is located on, a URL with the path /admin/tool/custompage.php is returned. This location doesn't exist, meaning that when clicking on the "Block location" crumb in the breadcrumb navigation, or when clicking "Save and display" after editing a sub-block, we are greeted with a 404 error. This pull request simply checks if the block is on a custom page and ensures that the correct URL is returned.