### PR TITLE
Settings page update subblock description and show only enabled blocks

### DIFF
--- a/lang/en/block_multiblock.php
+++ b/lang/en/block_multiblock.php
@@ -47,7 +47,7 @@ $string['multiblock_title_desc'] = 'This title will be displayed as the heading 
 $string['multiblock_presentation_style'] = 'Multiblock presentation style';
 $string['multiblock_presentation_style_desc'] = 'Select a multiblock presentation style to enhance the personal experience';
 $string['multiblock_subblock'] = 'Multiblock - Subblocks';
-$string['multiblock_subblock_desc'] = 'Multiple blocks can be selected';
+$string['multiblock_subblock_desc'] = 'Select the subblocks to be added by default to a new multiblock instance. ';
 $string['multiblock:addinstance'] = 'Add a Multiblock';
 $string['multiblock:myaddinstance'] = 'Add a Multiblock to Dashboard';
 

--- a/settings.php
+++ b/settings.php
@@ -27,7 +27,7 @@ defined('MOODLE_INTERNAL') || die;
 if ($ADMIN->fulltree) {
     global $DB, $PAGE, $CFG;
 
-    $blocks = $DB->get_records('block', array(), 'name ASC');
+    $blocks = $DB->get_records('block', array('visible' => 1), 'name ASC');
 
     // Multiblock title (heading).
     $settings->add(new admin_setting_configtext('block_multiblock/title', get_string('multiblock_title', 'block_multiblock'),


### PR DESCRIPTION
Kia ora,

On the plugin settings page, the setting block_multiblock/subblock is meant for the default multiblock instance creation. This commit adds clarity to this setting and addresses the issue106. 
Furthermore, it shows only the enabled blocks in the subblock dropdown to make the setting more useful. 
Refer to the below images for details:
![Screenshot from 2024-11-29 16-15-05](https://github.com/user-attachments/assets/e0358dce-0640-42a3-9b1d-3bfae6d3e6d7)
![Screenshot from 2024-11-29 16-15-28](https://github.com/user-attachments/assets/844cd2dd-d37d-41d7-a2f0-03265036302d)
![Screenshot from 2024-11-29 16-16-45](https://github.com/user-attachments/assets/dc4eef71-74f8-40b9-bd05-ca38c0bee3aa)



Please note: 

Cheers,
Sumaiya


