### PR TITLE
Add support for core dynamic_form

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -301,7 +301,10 @@ class helper {
         if (static::is_totara()) {
             return new editblock_totara($actionurl, $block, $page, $multiblock);
         } else {
-            return new editblock($actionurl, $block, $page, $multiblock);
+            $customdata['block'] = $block->blockinstance;
+            $customdata['page'] = $page;
+            $customdata['multiblock'] = $multiblock;
+            return new editblock($actionurl->out(false), $customdata, 'post');
         }
     }
 }


### PR DESCRIPTION
Hi,

This fixes the issue [104](https://github.com/catalyst/moodle-block_multiblock/issues/104) and [112](https://github.com/catalyst/moodle-block_multiblock/issues/112)

To replicate the issue do the below:
Add multiblock plugin to a Moodle 4.2 site and add a block 
Go to 'Manage contents' and click on the wheel icon to edit the block instance
![Screenshot from 2025-01-06 17-26-38](https://github.com/user-attachments/assets/5849ab89-d97b-45fa-8cf2-56011903c2d4)
It will lead to 
```
Fatal error: Cannot override final method core_form\dynamic_form::__construct() in blocks/multiblock/classes/form/editblock_base.php on line 60
```
Apply the change and see that the issue is resolved

**Note: This is for Moodle site 4.2 and above only.**

Cheers,
Sumaiya
