### PR TITLE
Add support for subblocks with text like block_course_list 

### DIFF
--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -53,9 +53,22 @@ class mobile {
             if (block_load_class($block->blockname)) {
                 // Make the proxy class we'll need.
                 $subblockinstance = block_instance($block->blockname, $block);
+                if ($subblockinstance->get_content()->text) {
+                    $content = $subblockinstance->get_content()->text;
+                } else {
+                    $rows = $subblockinstance->get_content();
+                    $content = '';
+                    foreach ($rows as $key => $items) {
+                        if ($key != 'footer') {
+                            if (!empty($items) && is_array($items)) {
+                                $content = implode(" - ", $items);
+                            }
+                        }
+                    }
+                }
                 $multiblock[$id]["id"] = $id;
                 $multiblock[$id]["title"] = $subblockinstance->get_title();
-                $multiblock[$id]["content"] = format_text($subblockinstance->get_content()->text);
+                $multiblock[$id]["content"] = $content;
             }
         }
         $data = [


### PR DESCRIPTION
Add support for subblocks with text like course_list 
And it will also fix the issue of some subblocks displaying broken HTML code.
However if a subblock has javascript in it then it will appear blank now like block_recentlyaccesseditems