### PR TITLE
Check Permissions of Subblocks

### DIFF
--- a/block_multiblock.php
+++ b/block_multiblock.php
@@ -214,6 +214,11 @@ class block_multiblock extends block_base {
             if (empty($block->blockinstance)) {
                 continue;
             }
+
+            if (!has_capability('moodle/block:view', $block->blockinstance->context)) {
+                continue;
+            }
+
             $content = $block->blockinstance->get_content_for_output($this->output);
             $multiblock[] = [
                 'id' => $id,

--- a/classes/icon_helper.php
+++ b/classes/icon_helper.php
@@ -138,4 +138,15 @@ class icon_helper {
             return $OUTPUT->pix_icon('i/empty', '');
         }
     }
+
+    /**
+     * Returns a permission icon.
+     *
+     * @return mixed An icon object for rendering.
+     */
+    public static function permission(string $str) {
+        global $OUTPUT;
+
+        return new pix_icon('i/permissions', $str, 'moodle', []);
+    }
 }

--- a/classes/icon_helper.php
+++ b/classes/icon_helper.php
@@ -141,11 +141,12 @@ class icon_helper {
 
     /**
      * Returns a permission icon.
+     * @param string $str
      *
      * @return mixed An icon object for rendering.
+     *
      */
     public static function permission(string $str) {
-        global $OUTPUT;
 
         return new pix_icon('i/permissions', $str, 'moodle', []);
     }

--- a/lang/en/block_multiblock.php
+++ b/lang/en/block_multiblock.php
@@ -51,6 +51,7 @@ $string['multiblock_subblock_desc'] = 'Select the subblocks to be added by defau
 $string['multiblock:addinstance'] = 'Add a Multiblock';
 $string['multiblock:myaddinstance'] = 'Add a Multiblock to Dashboard';
 
+$string['permissions'] = 'Permission';
 $string['presentation'] = 'Multiblock presentation style';
 $string['presentation:accordion'] = 'Accordion';
 $string['presentation:carousel'] = 'Carousel';

--- a/manage.php
+++ b/manage.php
@@ -130,6 +130,18 @@ if ($newblockdata = $addblock->get_data()) {
             blocks_delete_instance($blockinstance->instance);
             redirect($parenturl);
             break;
+        case 'permissions':
+            $returnurl = navigation::get_page_url($blockid);
+
+            $blockcontext = context_block::instance($actionableinstance);
+
+            $url = new moodle_url('/admin/roles/permissions.php', [
+                'contextid' => $blockcontext->id,
+                'returnurl' => $returnurl->out(),
+            ]);
+
+            redirect($url);
+            break;
     }
 }
 
@@ -209,6 +221,14 @@ if (empty($multiblockblocks)) {
         } else {
             $actions .= icon_helper::space();
         }
+
+        // Set the context permissions.
+        $url = $baseactionurl;
+        $url->params(['action' => 'permissions']);
+        $actions .= $OUTPUT->action_icon(
+            $url,
+            icon_helper::permission(get_string('permissions', 'block_multiblock'))
+        );
 
         // Split out to parent context.
         $url = $baseactionurl;


### PR DESCRIPTION
# Summary
This update improves permission handling by checking user capabilities at the sub-block level, rather than only at the multi-block context.

# Details
- Sub-blocks are now conditionally rendered based on whether the user has the `moodle/block:view` capability in the specific context.
- This enables use cases such as hiding specific tabs for users without the required permissions.
- Additionally, we’ve added a shortcut icon in manage.php that links directly to the permissions editing page for easier access.