### PR TITLE
fix: use 'spacer' instead of 'i/empty' pix icon

### DIFF
--- a/classes/icon_helper.php
+++ b/classes/icon_helper.php
@@ -135,7 +135,7 @@ class icon_helper {
         if (class_exists('\\core\\output\\flex_icon')) {
             return $OUTPUT->flex_icon('spacer');
         } else {
-            return $OUTPUT->pix_icon('i/empty', '');
+            return $OUTPUT->pix_icon('spacer', '', 'moodle', ['class' => 'iconsmall']);
         }
     }
 


### PR DESCRIPTION
Issue: `i/empty` is not the correct icon to use as a spacer and shows a visible icon

Resolution: use the `spacer` pix icon instead

| Before | After |
| ---------- | ------- |
| <img width="1310" height="558" alt="image" src="https://github.com/user-attachments/assets/476cf0f1-343e-4271-ae84-f8647e49f491" /> | <img width="1305" height="558" alt="image" src="https://github.com/user-attachments/assets/b010c875-0f46-49fc-a4d2-827c435bbfc4" /> |