### PR TITLE
Fix aria-controls targets on <li> tags

### DIFF
--- a/templates/dropdown-bootstrap3.mustache
+++ b/templates/dropdown-bootstrap3.mustache
@@ -50,7 +50,7 @@
             <ul class="dropdown-menu">
             {{#multiblock}}
                 <li>
-                    <a class="dropdown-item" id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="tab" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-tab-{{multiblockid}}-{{id}}">{{{title}}}</a>
+                    <a class="dropdown-item" id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="tab" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-{{multiblockid}}-{{id}}">{{{title}}}</a>
                 </li>
             {{/multiblock}}
             </ul>

--- a/templates/dropdown-bootstrap4.mustache
+++ b/templates/dropdown-bootstrap4.mustache
@@ -46,7 +46,7 @@
             <a class="nav-link dropdown-toggle active" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">{{#multiblock}}{{#active}}{{title}}{{/active}}{{/multiblock}}</a>
             <div class="dropdown-menu">
             {{#multiblock}}
-                <a class="dropdown-item" id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="tab" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-tab-{{multiblockid}}-{{id}}">{{{title}}}</a>
+                <a class="dropdown-item" id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="tab" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-{{multiblockid}}-{{id}}">{{{title}}}</a>
             {{/multiblock}}
             </div>
         </li>

--- a/templates/tabbed-list-bootstrap3.mustache
+++ b/templates/tabbed-list-bootstrap3.mustache
@@ -44,7 +44,7 @@
     <ul class="nav nav-tabs" id="multiblock-container-{{multiblockid}}" role="tablist">
         {{#multiblock}}
             <li role="presentation"{{#active}} class="active"{{/active}}>
-                <a id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="tab" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-tab-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
+                <a id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="tab" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
             </li>
         {{/multiblock}}
     </ul>

--- a/templates/tabbed-list-bootstrap4.mustache
+++ b/templates/tabbed-list-bootstrap4.mustache
@@ -44,7 +44,7 @@
     <ul class="nav nav-tabs" id="multiblock-container-{{multiblockid}}" role="tablist">
         {{#multiblock}}
             <li class="nav-item">
-                <a class="nav-link{{#active}} active{{/active}}" id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="tab" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-tab-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
+                <a class="nav-link{{#active}} active{{/active}}" id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="tab" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
             </li>
         {{/multiblock}}
     </ul>

--- a/templates/tabbed-list-columns-2-66-33-bootstrap3.mustache
+++ b/templates/tabbed-list-columns-2-66-33-bootstrap3.mustache
@@ -45,7 +45,7 @@
         {{#multiblock}}
             {{#is_odd}}
                 <li role="presentation"{{#active}} class="active"{{/active}}>
-                    <a id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="tab" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-tab-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
+                    <a id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="tab" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
                 </li>
             {{/is_odd}}
         {{/multiblock}}

--- a/templates/tabbed-list-columns-2-66-33-bootstrap4.mustache
+++ b/templates/tabbed-list-columns-2-66-33-bootstrap4.mustache
@@ -45,7 +45,7 @@
         {{#multiblock}}
             {{#is_odd}}
                 <li class="nav-item">
-                    <a class="nav-link{{#active}} active{{/active}}" id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="tab" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-tab-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
+                    <a class="nav-link{{#active}} active{{/active}}" id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="tab" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
                 </li>
             {{/is_odd}}
         {{/multiblock}}

--- a/templates/vertical-tabbed-list-bootstrap3.mustache
+++ b/templates/vertical-tabbed-list-bootstrap3.mustache
@@ -46,7 +46,7 @@
             <ul class="nav nav-stacked nav-pills" id="multiblock-container-{{multiblockid}}" role="tablist" aria-orientation="vertical">
                 {{#multiblock}}
                     <li role="presentation" class="{{#active}} active{{/active}}">
-                        <a id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="pill" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-tab-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
+                        <a id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="pill" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
                     </li>
                 {{/multiblock}}
             </ul>

--- a/templates/vertical-tabbed-list-bootstrap4.mustache
+++ b/templates/vertical-tabbed-list-bootstrap4.mustache
@@ -45,7 +45,7 @@
         <div class="col-md-3">
             <div class="nav flex-column nav-pills" id="multiblock-container-{{multiblockid}}" role="tablist" aria-orientation="vertical">
                 {{#multiblock}}
-                    <a class="nav-link{{#active}} active{{/active}}" id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="pill" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-tab-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
+                    <a class="nav-link{{#active}} active{{/active}}" id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="pill" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
                 {{/multiblock}}
             </div>
         </div>

--- a/templates/vertical-tabbed-list-right-bootstrap3.mustache
+++ b/templates/vertical-tabbed-list-right-bootstrap3.mustache
@@ -59,7 +59,7 @@
             <ul class="nav nav-stacked nav-pills" id="multiblock-container-{{multiblockid}}" role="tablist" aria-orientation="vertical">
                 {{#multiblock}}
                     <li role="presentation" class="{{#active}} active{{/active}}">
-                        <a id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="pill" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-tab-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
+                        <a id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="pill" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
                     </li>
                 {{/multiblock}}
             </ul>

--- a/templates/vertical-tabbed-list-right-bootstrap4.mustache
+++ b/templates/vertical-tabbed-list-right-bootstrap4.mustache
@@ -58,7 +58,7 @@
         <div class="col-md-3">
             <div class="nav flex-column nav-pills" id="multiblock-container-{{multiblockid}}" role="tablist" aria-orientation="vertical">
                 {{#multiblock}}
-                    <a class="nav-link{{#active}} active{{/active}}" id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="pill" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-tab-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
+                    <a class="nav-link{{#active}} active{{/active}}" id="multiblock-tab-{{multiblockid}}-{{id}}" data-toggle="pill" href="#multiblock-{{multiblockid}}-{{id}}" role="tab" aria-controls="multiblock-{{multiblockid}}-{{id}}" aria-selected="{{#active}}true{{/active}}{{^active}}false{{/active}}">{{{title}}}</a>
                 {{/multiblock}}
             </div>
         </div>


### PR DESCRIPTION
This adds accessibility fixes to make sure that the aria-controls id is targeting the correct element rather than itself.